### PR TITLE
ci: pin versions of actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
             ${{ env.workspace }}/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Add rustfmt/clippy
-        run: | 
+        run: |
           rustup component add rustfmt
           rustup component add clippy
       - name: Run Cargo build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,23 +8,23 @@ jobs:
   docker-publish:
     runs-on: ubuntu-24.04
     permissions:
-        id-token: write
-        packages: write
-        contents: write
-        attestations: write
+      id-token: write
+      packages: write
+      contents: write
+      attestations: write
     env:
-        REGISTRY: ghcr.io
-        IMAGE: ${{ github.repository }}
-        APP_NAME: ratchet-dispatcher
+      REGISTRY: ghcr.io
+      IMAGE: ${{ github.repository }}
+      APP_NAME: ratchet-dispatcher
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # ratchet:docker/setup-buildx-action@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # ratchet:docker/setup-qemu-action@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # ratchet:docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
           tags: |
@@ -36,14 +36,14 @@ jobs:
             type=sha
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # ratchet:docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         id: build_and_push
         with:
           context: .
@@ -56,7 +56,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@534b352d658f90498fd148d231fdbf88f3886a3a # ratchet:actions/attest-build-provenance@v1
         id: attest
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE }}
@@ -66,10 +66,10 @@ jobs:
     name: Attach binaries, sbom and provenance to releases
     runs-on: ubuntu-24.04
     permissions:
-        id-token: write
-        packages: write
-        contents: write
-        attestations: write
+      id-token: write
+      packages: write
+      contents: write
+      attestations: write
     container: rust:1.76
     steps:
       - name: Checkout code
@@ -86,7 +86,7 @@ jobs:
           asset_name: ratchet-dispatcher
       - name: Attest build provenance
         id: attest
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@534b352d658f90498fd148d231fdbf88f3886a3a # ratchet:actions/attest-build-provenance@v1
         with:
           subject-path: 'target/release/ratchet-dispatcher'
       - name: Upload provenance to release


### PR DESCRIPTION
This automatically generated pull request upgrades the workflows using ratchet. It pins the versions of the actions used in the workflows to prevent bad actors from overwriting tags/versions. Please review the changes and merge if everything looks good.