### PR TITLE
fix: correct artifact name for SBOM action in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,7 +98,6 @@ jobs:
           asset_name: provenance.json
       - uses: anchore/sbom-action@7ccf588e3cf3cc2611714c2eeae48550fbc17552 # v0.15.11
         with:
-          artifact-name: sbom.spdx.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish SBOM assets
         uses: anchore/sbom-action/publish-sbom@7ccf588e3cf3cc2611714c2eeae48550fbc17552 # v0.15.11


### PR DESCRIPTION
Fixes an issue in the workflow: https://github.com/Brend-Smits/ratchet-dispatcher/actions/runs/17676068775/job/50238350714